### PR TITLE
Spell out the return type of crc32()

### DIFF
--- a/CRC32.pod
+++ b/CRC32.pod
@@ -11,6 +11,7 @@ String::CRC32 - Perl interface for cyclic redundancy check generation
 
     $somestring = "some string";
     $crc = crc32($somestring);
+    printf "%08x\n", $crc;
 
     open my $fh, '<', 'location/of/some.file' or die $!;
     binmode $fh;
@@ -19,7 +20,7 @@ String::CRC32 - Perl interface for cyclic redundancy check generation
 
 =head1 DESCRIPTION
 
-The B<CRC32> module calculates CRC sums of 32 bit lengths.
+The B<CRC32> module calculates CRC sums of 32 bit lengths as integers.
 It generates the same CRC values as ZMODEM, PKZIP, PICCHECK and
 many others.
 


### PR DESCRIPTION
I'm shopping around for a CRC32 implementation and this was the first one I spotted.
It looks really neat, but I couldn't tell the return type of `crc32()` from the documentation.
What do you think of these changes?