### PR TITLE
Quote $VERSION to preserve formatting

### DIFF
--- a/CRC32.pm
+++ b/CRC32.pm
@@ -11,7 +11,7 @@ use vars qw/ @ISA $VERSION @EXPORT_OK @EXPORT /;
 
 @ISA = qw(Exporter);
 
-$VERSION = 2.000;
+$VERSION = '2.000';
 
 # Items to export into caller's namespace by default
 @EXPORT = qw(crc32);


### PR DESCRIPTION
Lack of quoting is causing the version to be interpreted as 1.9 or 2 rather than the intended trailing zeroes.