### PR TITLE
Declare vars with our instead of use vars

### DIFF
--- a/CRC32.pm
+++ b/CRC32.pm
@@ -7,17 +7,15 @@ use warnings;
 require Exporter;
 use XSLoader ();
 
-use vars qw/ @ISA $VERSION @EXPORT_OK @EXPORT /;
+our @ISA = qw(Exporter);
 
-@ISA = qw(Exporter);
-
-$VERSION = 2.000;
+our $VERSION = 2.000;
 
 # Items to export into caller's namespace by default
-@EXPORT = qw(crc32);
+our @EXPORT = qw(crc32);
 
 # Other items we are prepared to export if requested
-@EXPORT_OK = qw();
+our @EXPORT_OK = qw();
 
 XSLoader::load( 'String::CRC32', $VERSION );
 


### PR DESCRIPTION
Requires Perl 5.6 but "use warnings" already does so this can be assumed.